### PR TITLE
Override LaminasViewRenderer

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Axleus\Htmx;
 
 use Laminas\Form\View\Helper\Form as LaminasFormHelper;
+use Mezzio\LaminasView\LaminasViewRenderer;
 
 final class ConfigProvider
 {
@@ -15,6 +16,7 @@ final class ConfigProvider
             'view_helpers'       => $this->getViewHelpers(),
             'view_helper_config' => $this->getViewHelperConfig(),
             'htmx_config'        => $this->getHtmxConfig(),
+            'templates'          => $this->getTemplates(),
         ];
     }
 
@@ -23,6 +25,7 @@ final class ConfigProvider
         return [
             'factories' => [
                 Middleware\HtmxMiddleware::class => Middleware\HtmxMiddlewareFactory::class,
+                LaminasViewRenderer::class       => Container\RendererFactory::class,
             ],
         ];
     }
@@ -57,7 +60,7 @@ final class ConfigProvider
     {
         return [
             'enable'   => true,
-            'app_name' => 'Mastering Mezzio',
+            //'app_name' => 'Mastering Mezzio',
             'config'   => [
                 'historyEnabled'          => true,
                 'historyCacheSize'        => 10,
@@ -97,12 +100,12 @@ final class ConfigProvider
     public function getTemplates(): array
     {
         return [
-            'paths' => [
-                'app'              => [__DIR__ . '/../templates/app'],
-                'error'            => [__DIR__ . '/../templates/error'],
-                'layout'           => [__DIR__ . '/../templates/layout'],
-                'app-endpoint'     => [__DIR__ . '/../templates/api-endpoint'],
-                'app-oob-partial'  => [__DIR__ . '/../templates/oob-partial'],
+            'layout' => 'htmx::layout',
+            'header' => 'htmx::header',
+            'body'   => 'htmx::body',
+            'footer' => 'htmx::footer',
+            'paths'  => [
+                'htmx'   => [__DIR__ . '/../../../../src/App/templates/htmx'],
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -93,4 +93,17 @@ final class ConfigProvider
             ],
         ];
     }
+
+    public function getTemplates(): array
+    {
+        return [
+            'paths' => [
+                'app'              => [__DIR__ . '/../templates/app'],
+                'error'            => [__DIR__ . '/../templates/error'],
+                'layout'           => [__DIR__ . '/../templates/layout'],
+                'app-endpoint'     => [__DIR__ . '/../templates/api-endpoint'],
+                'app-oob-partial'  => [__DIR__ . '/../templates/oob-partial'],
+            ],
+        ];
+    }
 }

--- a/src/Container/RendererFactory.php
+++ b/src/Container/RendererFactory.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axleus\Htmx\Container;
+
+use Axleus\Htmx\View\Renderer\HtmxRenderer;
+use Laminas\View\HelperPluginManager;
+use Laminas\View\Renderer\PhpRenderer;
+use Laminas\View\Resolver;
+use Mezzio\Helper\UrlHelperInterface;
+use Mezzio\Helper\ServerUrlHelper as BaseServerUrlHelper;
+use Mezzio\Helper\UrlHelper as BaseUrlHelper;
+use Mezzio\LaminasView\Exception;
+use Mezzio\LaminasView\LaminasViewRenderer;
+use Mezzio\LaminasView\ServerUrlHelper;
+use Mezzio\LaminasView\UrlHelper;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function is_array;
+use function is_numeric;
+use function sprintf;
+
+class RendererFactory
+{
+    public function __invoke(ContainerInterface $container): HtmxRenderer
+    {
+        $config     = $container->has('config') ? $container->get('config') : [];
+        $htmxConfig = $config['htmx_config'] ?? [];
+        $config     = $config['templates'] ?? [];
+        // Configuration
+        $resolver = new Resolver\AggregateResolver();
+        $resolver->attach(
+            new Resolver\TemplateMapResolver($config['map'] ?? []),
+            100
+        );
+
+        // Create or retrieve the renderer from the container
+        $renderer = $container->has(PhpRenderer::class)
+            ? $container->get(PhpRenderer::class)
+            : ($container->has('Zend\View\Renderer\PhpRenderer')
+                ? $container->get('Zend\View\Renderer\PhpRenderer')
+                : new PhpRenderer());
+        assert($renderer instanceof PhpRenderer);
+
+        $renderer->setResolver($resolver);
+
+        // Inject helpers
+        $this->injectHelpers($renderer, $container);
+
+        $defaultSuffix = $config['extension'] ?? $config['default_suffix'] ?? null;
+        // Inject renderer
+        $view = new HtmxRenderer(
+            renderer: $renderer,
+            layout: $config['layout'] ?? null,
+            defaultSuffix: $defaultSuffix,
+            enableHtmx: $htmxConfig['enable'] ?? null
+        );
+
+        // Add template paths
+        $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
+        foreach ($allPaths as $namespace => $paths) {
+            $namespace = is_numeric($namespace) ? null : $namespace;
+            foreach ((array) $paths as $path) {
+                $view->addPath($path, $namespace);
+            }
+        }
+
+        return $view;
+    }
+
+        /**
+     * Inject helpers into the PhpRenderer instance.
+     *
+     * If a HelperPluginManager instance is present in the container, uses that;
+     * otherwise, instantiates one.
+     *
+     * In each case, injects with the custom url/serverurl implementations.
+     *
+     * @throws Exception\MissingHelperException
+     */
+    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container): void
+    {
+        $helpers = $this->retrieveHelperManager($container);
+        $helpers->setAlias('url', BaseUrlHelper::class);
+        $helpers->setAlias('Url', BaseUrlHelper::class);
+        $helpers->setFactory(BaseUrlHelper::class, static function () use ($container): UrlHelper {
+            if (
+                ! $container->has(BaseUrlHelper::class)
+                && ! $container->has('Zend\Expressive\Helper\UrlHelper')
+            ) {
+                throw new Exception\MissingHelperException(sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseUrlHelper::class
+                ));
+            }
+            $helper = $container->has(BaseUrlHelper::class)
+                ? $container->get(BaseUrlHelper::class)
+                : $container->get('Zend\Expressive\Helper\UrlHelper');
+
+            assert($helper instanceof UrlHelperInterface);
+
+            return new UrlHelper($helper);
+        });
+
+        $helpers->setAlias('serverurl', BaseServerUrlHelper::class);
+        $helpers->setAlias('serverUrl', BaseServerUrlHelper::class);
+        $helpers->setAlias('ServerUrl', BaseServerUrlHelper::class);
+        $helpers->setFactory(BaseServerUrlHelper::class, static function () use ($container): ServerUrlHelper {
+            if (
+                ! $container->has(BaseServerUrlHelper::class)
+                && ! $container->has('Zend\Expressive\Helper\ServerUrlHelper')
+            ) {
+                throw new Exception\MissingHelperException(sprintf(
+                    'An instance of %s is required in order to create the "url" view helper; not found',
+                    BaseServerUrlHelper::class
+                ));
+            }
+
+            $helper = $container->has(BaseServerUrlHelper::class)
+                ? $container->get(BaseServerUrlHelper::class)
+                : $container->get('Zend\Expressive\Helper\ServerUrlHelper');
+            assert($helper instanceof BaseServerUrlHelper);
+
+            return new ServerUrlHelper($helper);
+        });
+
+        $renderer->setHelperPluginManager($helpers);
+    }
+
+    private function retrieveHelperManager(ContainerInterface $container): HelperPluginManager
+    {
+        if ($container->has(HelperPluginManager::class)) {
+            return $container->get(HelperPluginManager::class);
+        }
+
+        if ($container->has('Zend\View\HelperPluginManager')) {
+            return $container->get('Zend\View\HelperPluginManager');
+        }
+
+        return new HelperPluginManager($container);
+    }
+}

--- a/src/Middleware/HtmxMiddleware.php
+++ b/src/Middleware/HtmxMiddleware.php
@@ -63,20 +63,20 @@ class HtmxMiddleware implements MiddlewareInterface
             $routeName = $routeResult->getMatchedRouteName() ?? '';
         }
 
-        // setup the Htmx ViewModel
-        $model = new ViewModel();
-        $model->addChild(
-            new HeaderModel(
-                [
-                    'request' => $request,
-                    'appName' => $this->htmxConfig['app_name'],
-                    'title'   => $routeName,
-                ]
-            )
-        );
+        // // setup the Htmx ViewModel
+        // $model = new ViewModel();
+        // $model->addChild(
+        //     new HeaderModel(
+        //         [
+        //             'request' => $request,
+        //             'appName' => $this->htmxConfig['app_name'],
+        //             'title'   => $routeName,
+        //         ]
+        //     )
+        // );
 
-        $model->addChild(new FooterModel());
-        $request = $request->withAttribute(ModelInterface::class, $model);
+        // $model->addChild(new FooterModel());
+        // $request = $request->withAttribute(ModelInterface::class, $model);
         return $handler->handle($request);
     }
 }

--- a/src/View/Model/BodyModel.php
+++ b/src/View/Model/BodyModel.php
@@ -6,19 +6,19 @@ namespace Axleus\Htmx\View\Model;
 
 use Laminas\View\Model\ViewModel;
 
-final class FooterModel extends ViewModel
+final class BodyModel extends ViewModel
 {
     /**
      * What variable a parent model should capture this model to
      *
      * @var string
      */
-    protected $captureTo = 'footer';
+    protected $captureTo = 'content';
 
     /**
      * Template to use when rendering this model
      *
      * @var string
      */
-    protected $template = 'htmx::footer';
+    protected $template = 'htmx::body';
 }

--- a/src/View/Model/HeaderModel.php
+++ b/src/View/Model/HeaderModel.php
@@ -20,5 +20,5 @@ final class HeaderModel extends ViewModel
      *
      * @var string
      */
-    protected $template = 'app::header';
+    protected $template = 'htmx::header';
 }

--- a/src/View/Renderer/HtmxRenderer.php
+++ b/src/View/Renderer/HtmxRenderer.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axleus\Htmx\View\Renderer;
+
+use Axleus\Htmx\View\Model;
+use Laminas\Stdlib\SplStack;
+use Laminas\View\Helper;
+use Laminas\View\Model\ModelInterface;
+use Laminas\View\Model\ViewModel;
+use Laminas\View\Renderer\PhpRenderer;
+use Laminas\View\Renderer\RendererInterface;
+use Laminas\View\Resolver\AggregateResolver;
+use Mezzio\LaminasView\NamespacedPathStackResolver;
+use Mezzio\Template\ArrayParametersTrait;
+use Mezzio\Template\DefaultParamsTrait;
+use Mezzio\Template\Exception;
+use Mezzio\Template\TemplatePath;
+use Mezzio\Template\TemplateRendererInterface;
+
+use function get_debug_type;
+use function is_int;
+use function is_string;
+use function sprintf;
+
+/**
+ * Template implementation bridging laminas/laminas-view.
+ *
+ * This implementation provides additional capabilities.
+ *
+ * First, it always ensures the resolver is an AggregateResolver, pushing any
+ * non-Aggregate into a new AggregateResolver instance. Additionally, it always
+ * registers a NamespacedPathStackResolver at priority 0 (lower than
+ * default) in the Aggregate to ensure we can add and resolve namespaced paths.
+ */
+class HtmxRenderer implements TemplateRendererInterface
+{
+    use ArrayParametersTrait;
+    use DefaultParamsTrait;
+
+    private ?ViewModel $layout = null;
+    private NamespacedPathStackResolver $resolver;
+
+    /**
+     * Constructor
+     *
+     * Allows specifying the renderer to use (any laminas-view renderer is
+     * allowed), and optionally also the layout.
+     *
+     * The layout may be:
+     *
+     * - a string layout name
+     * - a ModelInterface instance representing the layout
+     *
+     * If no renderer is provided, a default PhpRenderer instance is created;
+     * omitting the layout indicates no layout should be used by default when
+     * rendering.
+     *
+     * @param null|string|ModelInterface $layout
+     * @param null|string $defaultSuffix The default template file suffix, if any
+     * @throws Exception\InvalidArgumentException For invalid $layout types.
+     */
+    public function __construct(
+        private ?RendererInterface $renderer = null,
+        $layout = null,
+        ?string $defaultSuffix = null,
+        private ?bool $enableHtmx = true
+    ) {
+        if (null === $renderer) {
+            $renderer = $this->createRenderer();
+            $resolver = $renderer->resolver();
+        } else {
+            $resolver = $renderer->resolver();
+            if (! $resolver instanceof AggregateResolver) {
+                $aggregate = $this->getDefaultResolver();
+                $aggregate->attach($resolver);
+                $resolver = $aggregate;
+            } elseif (! $this->hasNamespacedResolver($resolver)) {
+                $this->injectNamespacedResolver($resolver);
+            }
+        }
+
+        if (is_string($layout) && $layout !== '') {
+            $model = new ViewModel();
+            $model->setTemplate($layout);
+            $layout = $model;
+        }
+
+        if ($layout !== null && ! $layout instanceof ModelInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Layout must be a string layout template name or a %s instance; received %s',
+                ModelInterface::class,
+                get_debug_type($layout),
+            ));
+        }
+
+        $this->renderer = $renderer;
+        $this->resolver = $this->getNamespacedResolver($resolver);
+        if (null !== $defaultSuffix) {
+            $this->resolver->setDefaultSuffix($defaultSuffix);
+        }
+        $this->layout = $layout;
+    }
+
+    /**
+     * Render a template with the given parameters.
+     *
+     * If a layout was specified during construction, it will be used;
+     * alternately, you can specify a layout to use via the "layout"
+     * parameter/variable, using either:
+     *
+     * - a string layout template name
+     * - a Laminas\View\Model\ModelInterface instance
+     *
+     * Layouts specified with $params take precedence over layouts passed to
+     *
+     * @param array|ModelInterface|object $params
+     */
+    public function render(string $name, $params = []): string
+    {
+        $viewModel = $params instanceof ModelInterface
+            ? $this->mergeViewModel($name, $params)
+            : $this->createModel($name, $params);
+
+        $useLayout = false !== $viewModel->getVariable('layout', null);
+        if ($useLayout) {
+            $viewModel = $this->prepareLayout($viewModel);
+        }
+
+        return $this->renderModel($viewModel, $this->renderer);
+    }
+
+    /**
+     * Add a path for templates.
+     */
+    public function addPath(string $path, ?string $namespace = null): void
+    {
+        $this->resolver->addPath($path, $namespace);
+    }
+
+    /**
+     * Get the template directories
+     *
+     * @return TemplatePath[]
+     */
+    public function getPaths(): array
+    {
+        $paths = [];
+
+        /**
+         * @var array<array-key, SplStack<string>> $pathStack
+         */
+        $pathStack = $this->resolver->getPaths();
+        foreach ($pathStack as $namespace => $namespacedPaths) {
+            if (
+                $namespace === NamespacedPathStackResolver::DEFAULT_NAMESPACE
+                || empty($namespace)
+                || is_int($namespace)
+            ) {
+                $namespace = null;
+            }
+
+            foreach ($namespacedPaths as $path) {
+                $paths[] = new TemplatePath($path, $namespace);
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Create a view model from the template and parameters.
+     *
+     * @param string $name
+     * @return ModelInterface
+     */
+    private function createModel($name, mixed $params)
+    {
+        $params = $this->mergeParams($name, $this->normalizeParams($params));
+        $model  = new ViewModel($params);
+        $model->setTemplate($name);
+
+        if ($this->enableHtmx) {
+            $body = new Model\BodyModel();
+            $body->addChild(new Model\HeaderModel());
+            $body->addChild(new Model\FooterModel());
+            $body->addChild($model);
+            return $body;
+        }
+
+        return $model;
+    }
+
+    /**
+     * Do a recursive, depth-first rendering of a view model.
+     *
+     * @throws Exception\RenderingException If it encounters a terminal child.
+     */
+    private function renderModel(
+        ModelInterface $model,
+        RendererInterface $renderer,
+        ?ModelInterface $root = null
+    ): string {
+        if (! $root) {
+            $root = $model;
+        }
+
+        foreach ($model as $child) {
+            if ($child->terminate()) {
+                throw new Exception\RenderingException('Cannot render; encountered a child marked terminal');
+            }
+
+            $capture = $child->captureTo();
+            if (empty($capture)) {
+                continue;
+            }
+
+            $child = $this->mergeViewModel($child->getTemplate(), $child);
+
+            if ($child !== $root) {
+                $viewModelHelper = $renderer->plugin(Helper\ViewModel::class);
+                $viewModelHelper->setRoot($root);
+            }
+
+            $result = $this->renderModel($child, $renderer, $root);
+
+            if ($child->isAppend()) {
+                $oldResult = $model->{$capture};
+                $model->setVariable($capture, $oldResult . $result);
+                continue;
+            }
+
+            $model->setVariable($capture, $result);
+        }
+
+        return $renderer->render($model);
+    }
+
+    /**
+     * Returns a PhpRenderer object
+     */
+    private function createRenderer(): PhpRenderer
+    {
+        $renderer = new PhpRenderer();
+        $renderer->setResolver($this->getDefaultResolver());
+        return $renderer;
+    }
+
+    /**
+     * Get the default resolver
+     */
+    private function getDefaultResolver(): AggregateResolver
+    {
+        $resolver = new AggregateResolver();
+        $this->injectNamespacedResolver($resolver);
+        return $resolver;
+    }
+
+    /**
+     * Attaches a new NamespacedPathStackResolver to the AggregateResolver
+     *
+     * A priority of 0 is used, to ensure it is the last queried.
+     */
+    private function injectNamespacedResolver(AggregateResolver $aggregate): void
+    {
+        $aggregate->attach(new NamespacedPathStackResolver(), 0);
+    }
+
+    private function hasNamespacedResolver(AggregateResolver $aggregate): bool
+    {
+        return $this->getNamespacedResolver($aggregate) !== null;
+    }
+
+    private function getNamespacedResolver(AggregateResolver $aggregate): ?NamespacedPathStackResolver
+    {
+        foreach ($aggregate as $resolver) {
+            if ($resolver instanceof NamespacedPathStackResolver) {
+                return $resolver;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Merge global/template parameters with provided view model.
+     *
+     * @param string $name Template name.
+     */
+    private function mergeViewModel(string $name, ModelInterface $model): ModelInterface
+    {
+        $params = $this->mergeParams(
+            $name,
+            $this->normalizeParams($model->getVariables())
+        );
+        $model->setVariables($params);
+        $model->setTemplate($name);
+        return $model;
+    }
+
+    /**
+     * Prepare the layout, if any.
+     *
+     * Injects the view model in the layout view model, if present.
+     *
+     * If the view model contains a non-empty 'layout' variable, that value
+     * will be used to seed a layout view model, if:
+     *
+     * - it is a string layout template name
+     * - it is a ModelInterface instance
+     *
+     * If a layout is discovered in this way, it will override the one set in
+     * the constructor, if any.
+     *
+     * Returns the provided $viewModel unchanged if no layout is discovered;
+     * otherwise, a view model representing the layout, with the provided
+     * view model as a child, is returned.
+     */
+    private function prepareLayout(ModelInterface $viewModel): ModelInterface
+    {
+        $providedLayout = $viewModel->getVariable('layout', null);
+        if (is_string($providedLayout) && ! empty($providedLayout)) {
+            $layout = new ViewModel();
+            $layout->setTemplate($providedLayout);
+            $viewModel->setVariable('layout', null);
+        } elseif ($providedLayout instanceof ModelInterface) {
+            $layout = $providedLayout;
+            $viewModel->setVariable('layout', null);
+        } else {
+            $layout = $this->layout ? clone $this->layout : null;
+        }
+
+        if ($layout) {
+            $layout->addChild($viewModel);
+            $viewModel = $layout;
+            $viewModel->setVariables($this->mergeParams($layout->getTemplate(), (array) $layout->getVariables()));
+        }
+
+        return $viewModel;
+    }
+}


### PR DESCRIPTION
Overrides LaminasViewRenderer to provide standard userland usage when calling render in handlers when Htmx is enabled.